### PR TITLE
fix keep alive workflow

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'channel-mirrors/mirrormirror'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: gautamkrishnar/keepalive-workflow@5b3128727d02fe1a892d0a2987517c9ec8ca7425  # v1.2.3
         with:
           commit_message: "Ah ah ah, stayin' alive"

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -2,7 +2,10 @@ name: Keep Alive
 on:
   # pull_request:
   schedule:
-    - cron: "0 6 * * SUN"  # Once weekly on Sunday @ 0600 UTC 
+    - cron: "0 6 * * SUN"  # Once weekly on Sunday @ 0600 UTC
+
+permissions:
+  contents: write
 
 jobs:
   keep-alive:
@@ -11,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: gautamkrishnar/keepalive-workflow@790c7f09285a59b09bb578c85e271c6ff2af97c4
+      - uses: gautamkrishnar/keepalive-workflow@5b3128727d02fe1a892d0a2987517c9ec8ca7425  # v1.2.3
         with:
           commit_message: "Ah ah ah, stayin' alive"
           committer_username: "github-actions[bot]"


### PR DESCRIPTION
Mirroring jobs stopped working a while ago because the keep alive workflow stopped working a while ago due to some Github-side changes in the permission system.