### PR TITLE
Use commits for keep alive again

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -17,3 +17,7 @@ jobs:
       - uses: gautamkrishnar/keepalive-workflow@beb86212524e1ae856d1cd80efb44e73bf7daf4a  # v2.0.1
         with:
           time_elapsed: 30  # days
+          use_api: false
+          commit_message: "Ah ah ah, stayin' alive"
+          committer_username: "github-actions[bot]"
+          committer_email: "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b  # v4
-      - uses: gautamkrishnar/keepalive-workflow@beb86212524e1ae856d1cd80efb44e73bf7daf4a  # v2.0.1
+      - uses: gautamkrishnar/keepalive-workflow@beb86212524e1ae856d1cd80efb44e73bf7daf4a  # 2.0.1
         with:
           time_elapsed: 30  # days
           use_api: false


### PR DESCRIPTION
The keep alive v2 action allows to use the GH API instead of dummy commits. However, it comes with a few pitfalls 🤔

- The API call keeps a workflow alive, not the entire repository. So we need to either add the step to every workflow to keep alive, or use the workflows setting. This is prone to break.
- We need to update the permissions in the workflow too. Note this was not properly configured before either, and probably would have ended up failing.

For that reason, I'm reverting back to commit mode (`use_api: false`) that simply keeps everything operational without further work (and it's also future proof in case more cron based workflows are added). I don't think we care too much about the commit history, but let me know otherwise.